### PR TITLE
add missing import

### DIFF
--- a/pyads/pyads.py
+++ b/pyads/pyads.py
@@ -12,6 +12,7 @@
 
 from ctypes import *
 from constants import *
+from structs import *
 
 # load dynamic ADS library
 _adsDLL = CDLL("TcAdsDll.dll") #: ADS-DLL (Beckhoff TwinCAT)


### PR DESCRIPTION
In line 66, the name `SAmsAddr` was not defined because of a missing import. This PR should fix this.