### PR TITLE
remove return code from adsDelRoute (adslib does not provide it)

### DIFF
--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -112,10 +112,7 @@ def adsDelRoute(net_id):
     delete_route = _adsDLL.AdsDelRoute
     delete_route.restype = ctypes.c_long
 
-    error_code = delete_route(net_id)
-
-    if error_code:
-        raise ADSError(error_code)
+    delete_route(net_id)
 
 
 def adsPortOpenEx():

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -110,8 +110,6 @@ def adsDelRoute(net_id):
     """
 
     delete_route = _adsDLL.AdsDelRoute
-    delete_route.restype = ctypes.c_long
-
     delete_route(net_id)
 
 


### PR DESCRIPTION
I have no clue about python, but would that be the way to go to correct the close error?