### PR TITLE
enhancement: passing an integer to the callback

### DIFF
--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -254,12 +254,12 @@ def delete_route(adr):
     return adsDelRoute(adr.netIdStruct())
 
 
-def add_device_notification(adr, data_name, attr, callback):
+def add_device_notification(adr, data_name, attr, callback, userInt = None):
     if linux:
         return adsSyncAddDeviceNotificationReqEx(port, adr, data_name, attr,
-                                                 callback)
+                                                 callback, userInt)
     else:
-        return adsSyncAddDeviceNotificationReq(adr, data_name, attr, callback)
+        return adsSyncAddDeviceNotificationReq(adr, data_name, attr, callback, userInt)
 
 
 def del_device_notification(adr, notification, hUser):
@@ -481,7 +481,7 @@ class Connection(object):
             return adsSyncWriteByName(self._adr, data_name, value,
                                       plc_datatype)
 
-    def add_device_notification(self, data_name, attr, callback):
+    def add_device_notification(self, data_name, attr, callback, userInt = None):
         """
         :summary: Add a device notification
 
@@ -520,10 +520,10 @@ class Connection(object):
         """
         if linux:
             return adsSyncAddDeviceNotificationReqEx(self._port, self._adr,
-                                                     data_name, attr, callback)
+                                                     data_name, attr, callback, userInt)
         else:
             return adsSyncAddDeviceNotificationReq(self._adr, data_name,
-                                                   attr, callback)
+                                                   attr, callback, userInt)
 
     def del_device_notification(self, notification, hUser):
         """

--- a/pyads/ads.py
+++ b/pyads/ads.py
@@ -12,7 +12,8 @@ from .pyads import (
     adsSyncWriteReq, adsSyncReadWriteReq, adsSyncReadReq,
     adsSyncReadByName, adsSyncWriteByName, adsSyncReadStateReq,
     adsSyncWriteControlReq, adsSyncReadDeviceInfoReq, adsGetLocalAddress,
-    adsSyncAddDeviceNotificationReq, adsSyncDelDeviceNotificationReq
+    adsSyncAddDeviceNotificationReq, adsSyncDelDeviceNotificationReq,
+    adsSyncSetTimeout
 )
 
 from .pyads_ex import (
@@ -20,7 +21,8 @@ from .pyads_ex import (
     adsGetLocalAddressEx, adsSyncReadStateReqEx, adsSyncReadDeviceInfoReqEx,
     adsSyncWriteControlReqEx, adsSyncWriteReqEx, adsSyncReadWriteReqEx2,
     adsSyncReadReqEx2, adsSyncReadByNameEx, adsSyncWriteByNameEx,
-    adsSyncAddDeviceNotificationReqEx, adsSyncDelDeviceNotificationReqEx
+    adsSyncAddDeviceNotificationReqEx, adsSyncDelDeviceNotificationReqEx,
+    adsSyncSetTimeoutEx
 )
 
 from .structs import AmsAddr
@@ -268,6 +270,11 @@ def del_device_notification(adr, notification, hUser):
     else:
         adsSyncDelDeviceNotificationReq(adr, notification, hUser)
 
+def set_timeout(ms):
+    if linux:
+        adsSyncSetTimeoutEx(port, ms)
+    else:
+        adsSyncSetTimeout(ms)
 
 class Connection(object):
     """
@@ -549,3 +556,9 @@ class Connection(object):
         :return: True if connection is open
         """
         return self._open
+
+    def set_timeout(self, ms):
+        if linux:
+            adsSyncSetTimeoutEx(self._port, ms)
+        else:
+            adsSyncSetTimeout(ms)

--- a/pyads/pyads.py
+++ b/pyads/pyads.py
@@ -457,3 +457,12 @@ def adsSyncDelDeviceNotificationReq(adr, hNotification, hUser):
         raise ADSError(err_code)
 
     adsSyncWriteReq(adr, ADSIGRP_SYM_RELEASEHND, 0, hUser, PLCTYPE_UDINT)
+
+@win32_only
+def adsSyncSetTimeout(nMs):
+    adsSyncSetTimeoutFct = \
+        _adsDLL.AdsSyncSetTimeout
+    cms = c_long(nMs)
+    err_code = adsSyncSetTimeoutFct(cms)
+    if err_code:
+        raise ADSError(err_code)

--- a/pyads/pyads.py
+++ b/pyads/pyads.py
@@ -403,7 +403,7 @@ callback_store = dict()
 
 
 @win32_only
-def adsSyncAddDeviceNotificationReq(adr, data_name, pNoteAttrib, callback):
+def adsSyncAddDeviceNotificationReq(adr, data_name, pNoteAttrib, callback, userInt = None):
     global callback_store   # use global variable to prevent garbage collection
     adsSyncAddDeviceNotificationReqFct = \
         _adsDLL.AdsSyncAddDeviceNotificationReq
@@ -418,6 +418,9 @@ def adsSyncAddDeviceNotificationReq(adr, data_name, pNoteAttrib, callback):
 
     pNotification = ctypes.c_ulong()
     nHUser = ctypes.c_ulong(hnl)
+    if userInt != None and type(userInt) in [int, long]:
+        nHUser = ctypes.c_ulong(userInt)
+        
     if NOTEFUNC is None:
         raise TypeError("Callback function type can't be None")
     adsSyncAddDeviceNotificationReqFct.argtypes = [

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -566,3 +566,10 @@ def adsSyncDelDeviceNotificationReqEx(port, adr, hNotification, hUser):
 
     adsSyncWriteReqEx(port, adr, ADSIGRP_SYM_RELEASEHND, 0, hUser,
                       PLCTYPE_UDINT)
+
+def adsSyncSetTimeoutEx(port, nMs):
+    adsSyncSetTimeoutFct = _adsDLL.AdsSyncSetTimeoutEx
+    cms = c_long(nMs)
+    err_code = adsSyncSetTimeoutFct(port, cms)
+    if err_code:
+        raise ADSError(err_code)

--- a/pyads/pyads_ex.py
+++ b/pyads/pyads_ex.py
@@ -510,7 +510,7 @@ def adsSyncWriteByNameEx(port, address, data_name, value, data_type):
 
 
 def adsSyncAddDeviceNotificationReqEx(port, adr, data_name, pNoteAttrib,
-                                      callback):
+                                      callback, userInt = None):
     global callback_store
 
     adsSyncAddDeviceNotificationReqFct = \
@@ -525,6 +525,9 @@ def adsSyncAddDeviceNotificationReqEx(port, adr, data_name, pNoteAttrib,
     attrib = pNoteAttrib.notificationAttribStruct()
     pNotification = ctypes.c_ulong()
     nHUser = ctypes.c_ulong(hnl)
+    if userInt != None and type(userInt) in [int, long]:
+        nHUser = ctypes.c_ulong(userInt)
+    
     if LNOTEFUNC is None:
         raise TypeError("Callback function type can't be None")
     adsSyncAddDeviceNotificationReqFct.argtypes = [


### PR DESCRIPTION
Hey Stefan,
this feature from the device notification hasn't been implemented jet. Unitl now the call would pass the handle as default value. However, as I understand it, you can pass any value:
hUser
    [in] 32-bit value that is passed to the callback function.
Regards,
Peter